### PR TITLE
에러 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,10 +68,10 @@ dependencies {
     }
 
     with(Test) {
-        implementation(JUNIT)
-        implementation(TRUTH)
-        implementation(CORE_TEST)
-        implementation(MOCKK)
+        testImplementation(JUNIT)
+        testImplementation(TRUTH)
+        testImplementation(CORE_TEST)
+        testImplementation(MOCKK)
     }
 }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
     }
 
     with(Test) {
-        implementation(JUNIT)
-        implementation(TRUTH)
-        implementation(MOCKK)
+        testImplementation(JUNIT)
+        testImplementation(TRUTH)
+        testImplementation(MOCKK)
     }
 }

--- a/data/src/test/kotlin/com/github/dodobest/data/data/UpbitAPITest.kt
+++ b/data/src/test/kotlin/com/github/dodobest/data/data/UpbitAPITest.kt
@@ -21,7 +21,7 @@ internal class UpbitAPITest {
     private lateinit var retrofit: Retrofit
     private lateinit var upbitAPI: UpbitAPI
 
-    private val upbitTickerDataValue = listOf(100.0, 150.0, 50.0, 1000.0)
+    private val upbitTickerDataValue = listOf(100.0, 150.0, 0.5, 1000.0)
     private val upbitMarketDataBTC = listOf("KRW-BTC", "비트코인", "Bitcoin", "NONE")
     private val upbitMarketDataETH = listOf("KRW-ETH", "이더리움", "Ethereum", "NONE")
     private val upbitMarketDataNU = listOf("KRW-NU", "누사이퍼", "Nucypher", "CAUTION")

--- a/data/src/test/resources/upbitTickerSuccessData.json
+++ b/data/src/test/resources/upbitTickerSuccessData.json
@@ -3,7 +3,7 @@
     "market": "KRW-BTC",
     "opening_price": 100,
     "trade_price": 150,
-    "signed_change_price": 50,
+    "signed_change_rate": 0.5,
     "acc_trade_price_24h": 1000
   }
 ]

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     }
 
     with(Test) {
-        implementation(JUNIT)
-        implementation(MOCKK)
+        testImplementation(JUNIT)
+        testImplementation(MOCKK)
     }
 }


### PR DESCRIPTION
1. build.gradle에서 테스트 관련 의존성을 testImplementation이 아닌 Implementation로 추가해서 수정함
2. API를 이용해 수신하는 TickerData의 종류가 변경되었지만, UpbitAPITest.kt MockWebServer에서 사용하는upbitTickerSuccessData.json의 tickerData 종류를 변경하지 않아 테스트가 통과되지 않았다.
signed_change_price(TickerData) -> signed_change_rate(upbitTickerSuccessData.json)
원인을 찾는데 시간이 엄청 오래 걸렸다. 코드를 수정하면 관련 테스트 함수가 통과하는지 확인하는 습관을 가지자.